### PR TITLE
"gem install rroonga" failed by 404 Not Found

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -46,7 +46,7 @@ def install_groonga_locally(major, minor, micro)
 
   install_dir = local_groonga_install_dir
   Dir.chdir(local_groonga_base_dir) do
-    url = "http://groonga.org/files/groonga/#{tar_gz}"
+    url = "http://packages.groonga.org/source/groonga/#{tar_gz}"
     message("downloading %s...", url)
     open(url, "rb") do |input|
       File.open(tar_gz, "wb") do |output|


### PR DESCRIPTION
Hi!

I tried "gem install rroonga", but it failed.
Because extconf.rb will fetch http://groonga.org/files/groonga/groonga-1.2.0.tar.gz ,
but it is not found (404).

So I wrote a patch, extconf.rb will fetch a tarball from http://packages.groonga.org/source/groonga/ .

Please pull me.
