### PR TITLE
タグ番号がないgroongaでテストを実行すると失敗する

### DIFF
--- a/lib/groonga.rb
+++ b/lib/groonga.rb
@@ -63,7 +63,7 @@ module Groonga
     # バージョン.マイクロバージョン"</tt>という形式の文字列に
     # したもの。
     def version
-      VERSION.join(".")
+      VERSION.compact.join(".")
     end
 
     ##


### PR DESCRIPTION
groonga1.3.0を使用してテストを実行すると、タグがないため、
test-version.rbのtest_version(VersionTest)が以下のように失敗します。

<pre>
<"1.3.0."> expected to be =~
</\A\d+\.\d+\.\d+(?:\.\d+-[a-zA-Z\d]+)?\z/>.
</pre>


タグの扱いがわからなかったので、Groonga.version側で
不必要なnilをcompactするように修正しています。
