### PR TITLE
rroongaをWindows環境でもビルド済みgemを使わずにインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ source "http://rubygems.org/"
 
 gem 'pkg-config'
 gem 'json'
+gem 'archive-zip'
 
 group :development, :test do
   gem "test-unit", ">= 2.4.6"


### PR DESCRIPTION
"[groonga-dev,00752] rroongaをWindows環境でもビルド済みgemを使わずにインストール"で議論していたパッチです、遅くなりました。
WinXPやWin7等、複数環境での動作チェックに時間がかかってしまいました。

互換性は維持しているつもりです。今まで通りクロスコンパイルによるコンパイル済みgem作成も出来ると思います。
pull request しましたが、こちらでマージしてしまった方がよければおっしゃって下さい。
