### PR TITLE
Require groonga 2.0.4 or later

### DIFF
--- a/rroonga-build.rb
+++ b/rroonga-build.rb
@@ -19,7 +19,7 @@ module RroongaBuild
   module RequiredGroongaVersion
     MAJOR = 2
     MINOR = 0
-    MICRO = 3
+    MICRO = 4
     VERSION = [MAJOR, MINOR, MICRO]
   end
 


### PR DESCRIPTION
http://packages.groonga.org/source/groonga/ にあるソースが 2.0.4 になったため、
rake install ができない状態になっていました。
( groonga がインストールされていない環境だと、最新のバージョン(2.0.4)の rroonga を gem install したときにも発生しそうです)

上記の対応としてダウンロードする groonga のバージョンを修正してみたのですが、
対応としてはこれで適切でしたでしょうか。
