### PR TITLE
Patch to avoid a SEGV

### DIFF
--- a/ext/groonga/rb-grn-object.c
+++ b/ext/groonga/rb-grn-object.c
@@ -1009,6 +1009,8 @@ rb_grn_object_get_path (VALUE self)
     const char *path;
 
     rb_grn_object = SELF(self);
+    if (!rb_grn_object)
+        return Qnil;
     if (!rb_grn_object->object)
         return Qnil;
 


### PR DESCRIPTION
I found sometimes the result of SELF(self) can be NULL. So I made a patch to avoid it.
Please confirm.
