### PR TITLE
Fix Table#column performance issue

### DIFF
--- a/ext/groonga/rb-grn-table.c
+++ b/ext/groonga/rb-grn-table.c
@@ -557,8 +557,11 @@ rb_grn_table_get_column (VALUE self, VALUE rb_name)
         RbGrnObject *rb_grn_object;
         rb_grn_object = user_data->ptr;
         if (rb_grn_object) {
-            rb_ary_push(columns, rb_grn_object->self);
-            return rb_grn_object->self;
+            rb_column = rb_grn_object->self;
+            rb_ary_push(columns, rb_column);
+            rb_grn_named_object_set_name(RB_GRN_NAMED_OBJECT(DATA_PTR(rb_column)),
+                                         name, name_size);
+            return rb_column;
         }
     }
 
@@ -567,8 +570,6 @@ rb_grn_table_get_column (VALUE self, VALUE rb_name)
     if (owner) {
         rb_iv_set(rb_column, "table", self);
     }
-    rb_grn_named_object_set_name(RB_GRN_NAMED_OBJECT(DATA_PTR(rb_column)),
-                                 name, name_size);
 
     return rb_column;
 }


### PR DESCRIPTION
Table#columnで高速化のため？に保存しているデータに名前を付けていないために再利用できず、
Table#columnを呼ぶたびにメモリ使用量と処理時間が増加する。
Table#define_columnでは名前を付けて保存しているので、カラムを追加したコンテキストの間は問題なし。

適切に名前が付くように修正しました。
Groonga::Accessorで返すときに名前を付けるコードがありますが、
使わなさそうなので、それを消して、Groonga:XXXColumnを返すときに付けるようにしています。

テストコード

``` ruby

# -*- coding: utf-8 -*-
require 'benchmark'
require 'groonga'

def measure(try)
  n = 50000

  puts try
  table = Groonga[:Test]
  Benchmark.bm(12) do |x|
    x.report('empty loop') do
      n.times { }
    end
    x.report('column:') do
      n.times { table.column('col') }
    end
    x.report('columns:') do
      n.times { table.columns('col') }
    end
    x.report('have_column?') do
      n.times { table.have_column?('col') }
    end
  end
end

path = './test-table-column.db'
database = Groonga::Database.create(:path => path)
table = Groonga::Array.create(:name => 'Test')
table.define_column('col', 'ShortText')

puts 'immediate after column created'
measure '1st'
measure '2nd'

puts '----'

database.close
database = Groonga::Database.open(path)

puts 'after close/open'
measure '1st'
measure '2nd'

table.remove
database.remove
```

実行結果（修正前）

```
mmediate after column created
1st
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002321)
column:        0.010000   0.000000   0.010000 (  0.012531)
columns:       0.830000   1.090000   1.920000 (  1.925174)
have_column?   0.020000   0.000000   0.020000 (  0.014460)
2nd
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002325)
column:        0.010000   0.000000   0.010000 (  0.009489)
columns:       0.820000   1.060000   1.880000 (  1.879173)
have_column?   0.010000   0.000000   0.010000 (  0.013547)

after close/open
1st
                   user     system      total        real
empty loop     0.010000   0.000000   0.010000 (  0.003230)
column:        0.880000   0.000000   0.880000 (  0.914890)  ←slow
columns:       0.830000   1.090000   1.920000 (  1.926731)
have_column?   0.020000   0.000000   0.020000 (  0.015166)
2nd
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002493)
column:        2.610000   0.000000   2.610000 (  2.613050)  ←slower than 1st
columns:       0.830000   1.090000   1.920000 (  1.924592)
have_column?   0.020000   0.000000   0.020000 (  0.015035)
```

修正後

```
immediate after column created
1st
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.003233)
column:        0.020000   0.000000   0.020000 (  0.015196)
columns:       0.830000   1.090000   1.920000 (  1.924414)
have_column?   0.020000   0.000000   0.020000 (  0.014458)
2nd
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002317)
column:        0.010000   0.000000   0.010000 (  0.008472)
columns:       0.830000   1.090000   1.920000 (  1.917370)
have_column?   0.010000   0.000000   0.010000 (  0.013499)
----
after close/open
1st
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002374)
column:        0.010000   0.000000   0.010000 (  0.039058) ←ok
columns:       0.830000   1.090000   1.920000 (  1.906612)
have_column?   0.010000   0.000000   0.010000 (  0.014918)
2nd
                   user     system      total        real
empty loop     0.000000   0.000000   0.000000 (  0.002338)
column:        0.010000   0.000000   0.010000 (  0.008446) ←ok
columns:       0.840000   1.100000   1.940000 (  1.935288)
have_column?   0.010000   0.000000   0.010000 (  0.014691)
```
