### PR TITLE
Follow Groonga 4.0.3

### DIFF
--- a/rroonga-build.rb
+++ b/rroonga-build.rb
@@ -27,7 +27,7 @@ module RroongaBuild
   module LatestGroongaVersion
     MAJOR = 4
     MINOR = 0
-    MICRO = 2
+    MICRO = 3
     VERSION = [MAJOR, MINOR, MICRO]
   end
 


### PR DESCRIPTION
Groonga 4.0.3 has been released, but rroonga can't find it.

```
$ groonga --version
groonga 4.0.3 [linux-gnu,x86_64,utf8,match-escalation-threshold=0,nfkc,mecab,msgpack,zlib,lzo,epoll]

$ gem i -V rroonga
(snip)
checking for groonga version (>= 4.0.1)... no
downloading http://packages.groonga.org/source/groonga/groonga-4.0.2.tar.gz...^CERROR:  Interrupted
```
