### PR TITLE
Fix Column#rename to set new name on grn_named_object

### DIFF
--- a/ext/groonga/rb-grn-column.c
+++ b/ext/groonga/rb-grn-column.c
@@ -758,7 +758,7 @@ rb_grn_column_get_indexes (int argc, VALUE *argv, VALUE self)
 }
 
 /*
- * Renames the table to name.
+ * Renames the column to name.
  * @since 1.3.0
  * @overload rename(name)
  *   @param name [String] the new name
@@ -782,7 +782,8 @@ rb_grn_column_rename (VALUE self, VALUE rb_name)
     rc = grn_column_rename(context, column, name, name_size);
     rb_grn_context_check(context, self);
     rb_grn_rc_check(rc, self);
-
+    rb_grn_named_object_set_name(RB_GRN_NAMED_OBJECT(DATA_PTR(self)),
+                                 name, name_size);
     return self;
 }
 


### PR DESCRIPTION
カラム名をリネームしても、rb_grn_named_object_set_nameされないので、
前の名前でTable#columnを呼んでもカラムが返ってきてしまう。
### 再現コード（irbにコピペ用）

``` ruby
require 'groonga'

PATH = 'tmp_test_database'

begin
  db = Groonga::Database.create(:path => PATH)
rescue
  Groonga::Database.open(PATH).remove
  db = Groonga::Database.create(:path => PATH)
end

Groonga::Schema.define do |schema|
  schema.create_table('Table') do |table|
    table.text('column')
  end
end

'test column rename'
Groonga[:Table].column(:column)
Groonga[:Table].column(:column).rename('renamed')
Groonga[:Table].column(:column) # should be nil
Groonga[:Table].column(:renamed)

Groonga[:Table].column(:renamed).remove
Groonga[:Table].column(:renamed)

db.remove
```
