### PR TITLE
Add flags into Groonga::Normalizer#normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ contributed patches.)
 ## Thanks
 
 * Daijiro MORI: sent patches to support the latest Groonga.
-* Tasuku SUENAGA: sent bug reports.
+* Tasuku SUENAGA: sent patches and bug reports.
 * niku: sent bug reports.
 * dara:
   * wrote tests.

--- a/doc/po/ja.po
+++ b/doc/po/ja.po
@@ -5779,8 +5779,10 @@ msgstr "文字列を正規化します。"
 
 # @example
 msgid ""
-"# Normalizes \"ABC\" with the default normalizer\n"
-"Groonga::Normalizer.normalize(\"AbC\") # => \"abc\""
+"# Normalizes \"AbC DeF\" with the default normalizer (removing spaces)\n"
+"Groonga::Normalizer.normalize(\"AbC DeF\") # => \"abcdef\""
+"# Normalizes \"AbC DeF\" without removing spaces\n"
+"Groonga::Normalizer.normalize(\"AbC DeF\", 0) # => \"abc def\""
 msgstr ""
 
 # @overload

--- a/test/test-normalizer.rb
+++ b/test/test-normalizer.rb
@@ -21,4 +21,28 @@ class NormalizerTest < Test::Unit::TestCase
   def test_normalize
     assert_equal("abc", Groonga::Normalizer.normalize("AbC"))
   end
+
+  def test_normalize_with_space
+    assert_equal("abcdefgh", Groonga::Normalizer.normalize("AbC Def　gh"))
+  end
+
+  def test_normalize_with_space_explicitly
+    assert_equal("abcdefgh",
+                 Groonga::Normalizer.normalize("AbC Def　gh", Groonga::Normalizer::REMOVE_BLANK))
+  end
+
+  def test_normalize_group_text
+    assert_equal("キロメートルキロメートルキロメートルキロメートル",
+                 Groonga::Normalizer.normalize("㌖㌖㌖㌖"));
+  end
+
+  def test_normalize_keep_space
+    # full width space => half width space
+    assert_equal("abc def gh",
+                 Groonga::Normalizer.normalize("AbC Def　gh", 0))
+  end
+
+  def test_normalize_tilda
+    assert_equal("~~~", Groonga::Normalizer.normalize("~～〜"))
+  end
 end

--- a/test/test-normalizer.rb
+++ b/test/test-normalizer.rb
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (C) 2012  Kouhei Sutou <kou@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or


### PR DESCRIPTION
In the document http://ranguba.org/rroonga/ja/file.news.html#__52 , they said 「今はこのメソッドは空白を自動で削除しますが、カスタマイズ可能にする予定です。」 in Japanese. It means the method always delete white spaces but it'll be customizable in future in English.

I made the patch enables customization without eliminating white spaces.