### PR TITLE
test: check mecab availability

### DIFF
--- a/test/groonga-test-utils.rb
+++ b/test/groonga-test-utils.rb
@@ -189,4 +189,8 @@ module GroongaTestUtils
   def need_encoding
     omit("Encoding is needed.") unless defined?(::Encoding)
   end
+
+  def check_mecab_availability
+    omit("MeCab isn't available") if context["TokenMecab"].nil?
+  end
 end

--- a/test/test-table-select-mecab.rb
+++ b/test/test-table-select-mecab.rb
@@ -20,10 +20,7 @@ class TableSelectMecabTest < Test::Unit::TestCase
 
   setup :setup_database
 
-  setup
-  def check_mecab_availability
-    omit("MeCab isn't available") if context["TokenMecab"].nil?
-  end
+  setup :check_mecab_availability
 
   setup
   def setup_tables

--- a/test/test-type.rb
+++ b/test/test-type.rb
@@ -153,6 +153,7 @@ class TypeTest < Test::Unit::TestCase
     end
 
     def test_mecab
+      check_mecab_availability
       assert_equal_type("TokenMecab",  Groonga::Type::MECAB)
     end
   end


### PR DESCRIPTION
ひとまず、既存のテストに合わせてMeCabがインストールされていなかった場合はomitするようにしました。
Travis CIにMeCabをインストールする方法については別途考えます。