### PR TITLE
Revert "Add Groonga::Type::REGEXP for TokenRegexp"

### DIFF
--- a/ext/groonga/rb-grn-type.c
+++ b/ext/groonga/rb-grn-type.c
@@ -278,5 +278,4 @@ rb_grn_init_type (VALUE mGrn)
     rb_define_const(rb_cGrnType, "BIGRAM", INT2NUM(GRN_DB_BIGRAM));
     rb_define_const(rb_cGrnType, "TRIGRAM", INT2NUM(GRN_DB_TRIGRAM));
     rb_define_const(rb_cGrnType, "MECAB", INT2NUM(GRN_DB_MECAB));
-    rb_define_const(rb_cGrnType, "REGEXP", INT2NUM(GRN_OP_REGEXP));
 }

--- a/test/test-type.rb
+++ b/test/test-type.rb
@@ -156,9 +156,5 @@ class TypeTest < Test::Unit::TestCase
       check_mecab_availability
       assert_equal_type("TokenMecab",  Groonga::Type::MECAB)
     end
-
-    def test_regexp
-      assert_equal_type("TokenRegexp",  Groonga::Type::REGEXP)
-    end
   end
 end


### PR DESCRIPTION
Reverts ranguba/rroonga#76

`GRN_OP_REGEXP` isn't type.