### PR TITLE
Add a test for beginning of text anchor (\A) of Regexp for block style

### DIFF
--- a/test/test-expression-builder.rb
+++ b/test/test-expression-builder.rb
@@ -291,6 +291,14 @@ class ExpressionBuilderTest < Test::Unit::TestCase
         assert_equal([],
                      result.collect {|record| record.key.key}.sort)
       end
+
+      def test_beginning_of_text
+        result = @users.select do |record|
+          record["name"] =~ /\Ash/
+        end
+        assert_equal(["suzuki"],
+                     result.collect {|record| record.key.key}.sort)
+      end
     end
 
     class QueryStringTest < self


### PR DESCRIPTION
GitHub: #70

#90 のpull requestはデータが不適切（`\A`があってもなくても結果が変わらない）だったので修正しました。