### PR TITLE
Add a test for beginning of text anchor (\A) of Regexp for query string

### DIFF
--- a/test/test-expression-builder.rb
+++ b/test/test-expression-builder.rb
@@ -313,6 +313,12 @@ class ExpressionBuilderTest < Test::Unit::TestCase
         assert_equal([],
                      result.collect {|record| record.key.key}.sort)
       end
+
+      def test_beginning_of_text
+        result = @users.select("name:~\\\\As")
+        assert_equal(["suzuki"],
+                     result.collect {|record| record.key.key}.sort)
+      end
     end
   end
 


### PR DESCRIPTION
GitHub: #70