### PR TITLE
Use rake compiler dock

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -148,7 +148,7 @@ namespace :clean do
   end
 end
 
-def target_rubies
+def cross_target_rubies
   "2.0.0:2.1.6:2.2.2"
 end
 
@@ -165,7 +165,7 @@ namespace :build do
     RakeCompilerDock.sh %Q[
       bundle
       rake clean
-      rake cross native gem RUBY_CC_VERSION=\"#{target_rubies}\"
+      rake cross native gem RUBY_CC_VERSION=\"#{cross_target_rubies}\"
     ]
   end
 end
@@ -179,7 +179,7 @@ namespace :build do
       bundle
       rake clean
       export RROONGA_USE_GROONGA_X64=true
-      rake cross native gem RUBY_CC_VERSION=\"#{target_rubies}\"
+      rake cross native gem RUBY_CC_VERSION=\"#{cross_target_rubies}\"
     ]
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -148,11 +148,30 @@ namespace :clean do
   end
 end
 
+def target_rubies
+  "2.0.0:2.1.6:2.2.2"
+end
+
 desc "Build cross compile binary with rake-compiler-dock"
 namespace :build do
-  task :windows do
+  task :windows => [:windows_x86, :windows_x64]
+end
+
+desc "Build cross compile binary with rake-compiler-dock for i386"
+namespace :build do
+  task :windows_x86 do
     require "rake_compiler_dock"
-    RakeCompilerDock.sh "bundle && rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2"
+    rm_rf binary_dir
+    RakeCompilerDock.sh "gem install yard packnga pkg-config && bundle && bundle exec rake clean && rake cross native gem RUBY_CC_VERSION=#{target_rubies}"
+  end
+end
+
+desc "Build cross compile binary with rake-compiler-dock for x64"
+namespace :build do
+  task :windows_x64 do
+    require "rake_compiler_dock"
+    rm_rf binary_dir
+    RakeCompilerDock.sh "gem install yard packnga pkg-config && bundle && bundle exec rake clean && RROONGA_USE_GROONGA_X64=true rake cross native gem RUBY_CC_VERSION=#{target_rubies}"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -162,7 +162,11 @@ namespace :build do
   task :windows_x86 do
     require "rake_compiler_dock"
     rm_rf binary_dir
-    RakeCompilerDock.sh "gem install yard packnga pkg-config && bundle && bundle exec rake clean && rake cross native gem RUBY_CC_VERSION=#{target_rubies}"
+    RakeCompilerDock.sh %Q[
+      bundle
+      rake clean
+      rake cross native gem RUBY_CC_VERSION=\"#{target_rubies}\"
+    ]
   end
 end
 
@@ -171,7 +175,12 @@ namespace :build do
   task :windows_x64 do
     require "rake_compiler_dock"
     rm_rf binary_dir
-    RakeCompilerDock.sh "gem install yard packnga pkg-config && bundle && bundle exec rake clean && RROONGA_USE_GROONGA_X64=true rake cross native gem RUBY_CC_VERSION=#{target_rubies}"
+    RakeCompilerDock.sh %Q[
+      bundle
+      rake clean
+      export RROONGA_USE_GROONGA_X64=true
+      rake cross native gem RUBY_CC_VERSION=\"#{target_rubies}\"
+    ]
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -148,16 +148,11 @@ namespace :clean do
   end
 end
 
-desc "Build cross compile binary with Vagrant"
+desc "Build cross compile binary with rake-compiler-dock"
 namespace :build do
   task :windows do
-    pkg_dir = "#{base_dir}/pkg"
-    mkdir pkg_dir unless File.exist?(pkg_dir)
-    cd "build/windows" do
-      sh("vagrant", "up")
-      cp(Dir.glob("pkg/rroonga-*-mingw32.gem"), pkg_dir)
-      sh("vagrant", "destroy", "-f")
-    end
+    require "rake_compiler_dock"
+    RakeCompilerDock.sh "bundle && rake cross native gem RUBY_CC_VERSION=2.0.0:2.1.6:2.2.2"
   end
 end
 

--- a/doc/text/cross-compile.md
+++ b/doc/text/cross-compile.md
@@ -56,19 +56,17 @@ $ bundle exec rake clean:groonga
 $ bundle exec rake RUBY_CC_VERSION=1.9.3:2.0.0:2.1.3 cross RROONGA_USE_GROONGA_X64=true clean native gem
 ```
 
-# For Vagrant tool Users
+# For rake-compiler-dock
 
-Vagrant is provided in `Windows`, `OS X` and `Linux(deb)/Linux(rpm)`.
+`rake-compiler-dock` depends `docker` or docker client such as `boot2docker`.
+Please install `docker` or docker client before cross compiling with `rake-compiler-dock`.
 
-## execute vagrant
+## cross compiling with rake-compiler-dock
 
-`build\windows\` directory contains Vagrantfile and its provisioning scripts.
-
-execute following command:
+execute following rake task:
 
 ```bash
-$ cd build\windows
-$ vagrant up
+$ bundle exec rake build:windows
 ```
 
 Then, `pkg` directory is created. And cross compiled gems move into `pkg` directory.

--- a/doc/text/cross-compile.md
+++ b/doc/text/cross-compile.md
@@ -58,8 +58,8 @@ $ bundle exec rake RUBY_CC_VERSION=1.9.3:2.0.0:2.1.3 cross RROONGA_USE_GROONGA_X
 
 # For rake-compiler-dock
 
-`rake-compiler-dock` depends `docker` or docker client such as `boot2docker`.
-Please install `docker` or docker client before cross compiling with `rake-compiler-dock`.
+`rake-compiler-dock` depends `docker` and some platform requires docker client such as `docker-machine`.
+Please install `docker` and docker client before cross compiling with `rake-compiler-dock`.
 
 ## cross compiling with rake-compiler-dock
 

--- a/rroonga.gemspec
+++ b/rroonga.gemspec
@@ -89,6 +89,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("test-unit-notify")
   s.add_development_dependency("rake")
   s.add_development_dependency("rake-compiler", [">= 0.9.5"])
+  s.add_development_dependency("rake-compiler-dock", ["~> 0.4.3"])
   s.add_development_dependency("bundler")
   s.add_development_dependency("yard")
   s.add_development_dependency("packnga", [">= 1.0.0"])


### PR DESCRIPTION
Building cross gem for Windows with rake-compiler-dock gem.

Note that this `rake-compiler-dock` rake task dose not support bundle install(1) --path option. Please use `bundle install` instead when you execute this rake task. And `rake-compiler-dock`'s Docker image does not contain cross ruby 1.9.3 x64, so I decided to drop Ruby 1.9.3 support.
