### PR TITLE
Add rroonga.rb for `Bundler.require`

### DIFF
--- a/lib/rroonga.rb
+++ b/lib/rroonga.rb
@@ -1,0 +1,1 @@
+require 'groonga'


### PR DESCRIPTION
`Bundler.require` will require rroonga.rb automatically.