### PR TITLE
Try to bind grn_get_global_error_message()

### DIFF
--- a/ext/groonga/rb-grn-global-error.c
+++ b/ext/groonga/rb-grn-global-error.c
@@ -1,0 +1,50 @@
+/* -*- coding: utf-8; mode: C; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+  Copyright (C) 2016  Masafumi Yokoyama <yokoyama@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "rb-grn.h"
+
+/*
+ * Document-class: Groonga::GlobalError
+ *
+ * This class manages global error in the current process.
+ */
+
+/*
+ * Gets the global error message in current process.
+ *
+ * @overload message
+ *   @return [String, nil] The error message.
+ *
+ * @since 6.0.0
+ */
+static VALUE
+rb_grn_global_error_get_message (VALUE klass)
+{
+    return rb_str_new_cstr(grn_get_global_error_message());
+}
+
+void
+rb_grn_init_global_error (VALUE mGrn)
+{
+    VALUE cGrnGlobalError;
+
+    cGrnGlobalError = rb_define_class_under(mGrn, "GlobalError", rb_cObject);
+
+    rb_define_singleton_method(cGrnGlobalError, "message",
+                               rb_grn_global_error_get_message, 0);
+}

--- a/ext/groonga/rb-grn.h
+++ b/ext/groonga/rb-grn.h
@@ -302,6 +302,7 @@ RB_GRN_VAR VALUE rb_cGrnColumnExpressionBuilder;
 RB_GRN_VAR VALUE rb_cGrnPlugin;
 RB_GRN_VAR VALUE rb_cGrnNormalizer;
 RB_GRN_VAR VALUE rb_cGrnIndex;
+RB_GRN_VAR VALUE rb_cGrnGlobalError;
 
 void           rb_grn_init_utils                    (VALUE mGrn);
 void           rb_grn_init_exception                (VALUE mGrn);
@@ -357,6 +358,7 @@ void           rb_grn_init_normalizer               (VALUE mGrn);
 void           rb_grn_init_thread                   (VALUE mGrn);
 void           rb_grn_init_config                   (VALUE mGrn);
 void           rb_grn_init_index                    (VALUE mGrn);
+void           rb_grn_init_global_error             (VALUE mGrn);
 
 VALUE          rb_grn_rc_to_exception               (grn_rc rc);
 const char    *rb_grn_rc_to_message                 (grn_rc rc);

--- a/ext/groonga/rb-groonga.c
+++ b/ext/groonga/rb-groonga.c
@@ -220,4 +220,5 @@ Init_groonga (void)
     rb_grn_init_thread(mGrn);
     rb_grn_init_config(mGrn);
     rb_grn_init_index(mGrn);
+    rb_grn_init_global_error(mGrn);
 }


### PR DESCRIPTION
I added `Groonga::GlobalError.message`, but I'm not sure about it.