### PR TITLE
Support INDEX_SMALL and INDEX_MEDIUM flags

### DIFF
--- a/ext/groonga/rb-grn-index-column.c
+++ b/ext/groonga/rb-grn-index-column.c
@@ -884,6 +884,56 @@ rb_grn_index_column_with_position_p (VALUE self)
 }
 
 /*
+ * Checks whether the object is a small size of index column.
+ *
+ * @overload small?
+ *   @return [Boolean] `true` if the object is a small size of index column,
+ *     `false` otherwise.
+ *
+ * @since 6.1.0
+ */
+static VALUE
+rb_grn_index_column_small_p (VALUE self)
+{
+    grn_obj *column;
+    grn_ctx *context;
+    grn_column_flags flags;
+
+    rb_grn_index_column_deconstruct(SELF(self), &column, &context,
+                                    NULL, NULL,
+                                    NULL, NULL, NULL, NULL, NULL,
+                                    NULL, NULL);
+
+    flags = grn_column_get_flags(context, column);
+    return CBOOL2RVAL(flags & GRN_OBJ_INDEX_SMALL);
+}
+
+/*
+ * Checks whether the object is a medium size of index column.
+ *
+ * @overload medium?
+ *   @return [Boolean] `true` if the object is a medium size of index column,
+ *     `false` otherwise.
+ *
+ * @since 6.1.0
+ */
+static VALUE
+rb_grn_index_column_medium_p (VALUE self)
+{
+    grn_obj *column;
+    grn_ctx *context;
+    grn_column_flags flags;
+
+    rb_grn_index_column_deconstruct(SELF(self), &column, &context,
+                                    NULL, NULL,
+                                    NULL, NULL, NULL, NULL, NULL,
+                                    NULL, NULL);
+
+    flags = grn_column_get_flags(context, column);
+    return CBOOL2RVAL(flags & GRN_OBJ_INDEX_MEDIUM);
+}
+
+/*
  * Opens cursor to iterate posting in the index column.
  *
  * @example
@@ -1310,6 +1360,10 @@ rb_grn_init_index_column (VALUE mGrn)
                      rb_grn_index_column_with_weight_p, 0);
     rb_define_method(rb_cGrnIndexColumn, "with_position?",
                      rb_grn_index_column_with_position_p, 0);
+    rb_define_method(rb_cGrnIndexColumn, "small?",
+                     rb_grn_index_column_small_p, 0);
+    rb_define_method(rb_cGrnIndexColumn, "medium?",
+                     rb_grn_index_column_medium_p, 0);
 
     rb_define_method(rb_cGrnIndexColumn, "open_cursor",
                      rb_grn_index_column_open_cursor, -1);

--- a/ext/groonga/rb-grn-object.c
+++ b/ext/groonga/rb-grn-object.c
@@ -927,6 +927,10 @@ rb_grn_object_inspect_content_flags_with_label (VALUE inspected,
             rb_ary_push(inspected_flags, rb_str_new_cstr("WITH_WEIGHT"));
         if (column_flags & GRN_OBJ_WITH_POSITION)
             rb_ary_push(inspected_flags, rb_str_new_cstr("WITH_POSITION"));
+        if (column_flags & GRN_OBJ_INDEX_SMALL)
+            rb_ary_push(inspected_flags, rb_str_new_cstr("SMALL"));
+        if (column_flags & GRN_OBJ_INDEX_MEDIUM)
+            rb_ary_push(inspected_flags, rb_str_new_cstr("MEDIUM"));
         break;
     default:
         break;

--- a/lib/groonga/dumper.rb
+++ b/lib/groonga/dumper.rb
@@ -487,6 +487,7 @@ module Groonga
         options[:with_section]  = true if column.with_section?
         options[:with_weight]   = true if column.with_weight?
         options[:with_position] = true if column.with_position?
+        options[:size] = column.size if column.small? or column.medium?
         arguments = [
           dump_object(target_table_name),
           sources.size == 1 ? source_names : "[#{source_names}]",
@@ -643,6 +644,8 @@ module Groonga
         flags << "WITH_SECTION" if column.with_section?
         flags << "WITH_WEIGHT" if column.with_weight?
         flags << "WITH_POSITION" if column.with_position?
+        flags << "INDEX_SMALL" if column.small?
+        flags << "INDEX_MEDIUM" if column.medium?
         parameters << "#{flags.join('|')}"
         parameters << "#{column.range.name}"
         source_names = column.sources.collect do |source|

--- a/lib/groonga/schema.rb
+++ b/lib/groonga/schema.rb
@@ -1697,6 +1697,7 @@ module Groonga
           :with_section => @options[:with_section],
           :with_weight => @options[:with_weight],
           :with_position => @options[:with_position],
+          :size => @options[:size]
         }
       end
 

--- a/test/test-index-column.rb
+++ b/test/test-index-column.rb
@@ -378,6 +378,65 @@ class IndexColumnTest < Test::Unit::TestCase
                      context["Tags.default"].with_position?,
                    ])
     end
+
+    class SizeTest < self
+      def test_small
+        Groonga::Schema.define do |schema|
+          schema.create_table("Tags",
+                              :type => :patricia_trie,
+                              :key_type => "ShortText") do |table|
+            table.index("Articles.tags",
+                        :name => "small",
+                        :size => :small)
+            table.index("Articles.tags",
+                        :name => "default")
+          end
+        end
+
+        assert_equal([
+                       true,
+                       false,
+                     ],
+                     [
+                       context["Tags.small"].small?,
+                       context["Tags.default"].small?,
+                     ])
+      end
+
+      def test_medium
+        Groonga::Schema.define do |schema|
+          schema.create_table("Tags",
+                              :type => :patricia_trie,
+                              :key_type => "ShortText") do |table|
+            table.index("Articles.tags",
+                        :name => "medium",
+                        :size => :medium)
+            table.index("Articles.tags",
+                        :name => "default")
+          end
+        end
+
+        assert_equal([
+                       true,
+                       false,
+                     ],
+                     [
+                       context["Tags.medium"].medium?,
+                       context["Tags.default"].medium?,
+                     ])
+      end
+
+      def test_invalid
+        Groonga::Schema.create_table("Tags",
+                                     :type => :patricia_trie,
+                                     :key_type => "ShortText")
+        assert_raise(ArgumentError.new("should pass :small or :medium.")) do
+          tags = Groonga["Tags"]
+          tags.define_index_column("small", Groonga["Articles"],
+                                   :size => "invalid")
+        end
+      end
+    end
   end
 
   class SourceTest < self


### PR DESCRIPTION
To use INDEX_SMALL and INDEX_MEDIUM which are added Groonga 6.0.8, use index_small => true or index_medium => true for index column.