### PR TITLE
Try to build for Windows with Groonga 7.1.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -168,6 +168,11 @@ namespace :build do
         mkdir_p build_dir
 
         commands = [
+          ["sudo", "apt-get", "-y", "install", "software-properties-common"],
+          ["sudo", "add-apt-repository", "-y", "universe"],
+          ["sudo", "add-apt-repository", "-y", "ppa:groonga/ppa"],
+          ["sudo", "apt-get", "update"],
+          ["sudo", "apt-get", "install", "-y", "libgroonga-dev"],
           ["git", "clone", "file://#{Dir.pwd}/.git", build_dir],
           ["cd", build_dir],
           ["gem", "install", "json"],

--- a/rroonga.gemspec
+++ b/rroonga.gemspec
@@ -89,7 +89,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("test-unit", [">= 3.0.0"])
   s.add_development_dependency("rake")
   s.add_development_dependency("rake-compiler", [">= 0.9.5"])
-  s.add_development_dependency("rake-compiler-dock", [">= 0.6.2"])
+  s.add_development_dependency("rake-compiler-dock", [">= 0.6.3"])
   s.add_development_dependency("bundler")
   s.add_development_dependency("yard")
   s.add_development_dependency("packnga", [">= 1.0.0"])


### PR DESCRIPTION
rake-compiler-deck 0.6.2 uses Ubuntu 17.04 Docker image, but
Groonga 7.1.1 dropped Ubuntu 17.04.

`rake build:windows`が`checking for groonga version (>= 7.1.1)... no`で失敗するので、いろいろ試していました。
rake-compiler-deck 0.6.3は、ローカルでUbuntu 17.10を使うように変更したものです。

* [Ubuntu 17.04 reached EOL on January 13, 2018 · Issue #17 · rake-compiler/rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock/issues/17)
* [groonga package : Ubuntu](https://launchpad.net/ubuntu/+source/groonga)
* [PPA for Groonga family : “Groonga” team](https://launchpad.net/~groonga/+archive/ubuntu/ppa)

このPRの変更によって`checking for groonga version (>= 7.1.1)...`は`yes`になったのですが、
以下のエラーで失敗してしまっています。

```
checking for groonga version (>= 7.1.1)... yes
checking for -Wl,-rpath is available... yes
checking for HAVE_RUBY_ST_H in ruby.h... yes
checking for rb_errinfo() in ruby.h... no
checking for rb_sym2str() in ruby.h... no
checking for rb_to_symbol() in ruby.h... no
checking for rb_ary_new_from_args() in ruby.h... no
checking for rb_ary_new_from_values() in ruby.h... no
checking for enum ruby_value_type in ruby.h... yes
checking for --enable-debug-log option... no
checking for --enable-debug-build option... no
checking for --enable-untyped-data-warning option... no
creating Makefile
cd -
cd tmp/x86-mingw32/groonga/2.1.6
/usr/bin/make
compiling ../../../../ext/groonga/rb-grn-inverted-index-cursor.c
In file included from ../../../../ext/groonga/rb-grn-inverted-index-cursor.c:19:0:
../../../../ext/groonga/rb-grn.h:58:21: fatal error: groonga.h: No such file or directory
 #include <groonga.h>
                     ^
compilation terminated.
Makefile:224: recipe for target 'rb-grn-inverted-index-cursor.o' failed
make: *** [rb-grn-inverted-index-cursor.o] Error 1
rake aborted!
Command failed with status (2): [/usr/bin/make...]
/usr/local/rvm/gems/ruby-2.4.3/gems/rake-compiler-1.0.4/lib/rake/extensiontask.rb:166:in `block (2 levels) in define_compile_tasks'
/usr/local/rvm/gems/ruby-2.4.3/gems/rake-compiler-1.0.4/lib/rake/extensiontask.rb:165:in `block in define_compile_tasks'
/usr/local/rvm/gems/ruby-2.4.3/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:15:in `eval'
/usr/local/rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => native => native:x86-mingw32 => native:rroonga:x86-mingw32 => tmp/x86-mingw32/stage/lib/2.1/groonga.so => copy:groonga:x86-mingw32:2.1.6 => tmp/x86-mingw32/groonga/2.1.6/groonga.so
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [docker run -v /home/myokoym/work/groonga/rroonga:/home/myokoym/work/groonga/rroonga -e UID\=1000 -e GID\=1000 -e USER\=myokoym -e GROUP\=myokoym -e ftp_proxy\= -e http_proxy\= -e https_proxy\= -e RCD_HOST_RUBY_PLATFORM\=x86_64-linux -e RCD_HOST_RUBY_VERSION\=2.5.0 -e RCD_IMAGE\=larskanis/rake-compiler-dock:0.6.3 -w /home/myokoym/work/groonga/rroonga --rm -i -t larskanis/rake-compiler-dock:0.6.3 runas sigfw bash -c sudo\ apt-get\ -y\ install\ software-properties-common\ \&\&\ sudo\ add-apt-repository\ -y\ universe\ \&\&\ sudo\ add-apt-repository\ -y\ ppa:groonga/ppa\ \&\&\ sudo\ apt-get\ update\ \&\&\ sudo\ apt-get\ install\ -y\ libgroonga-dev\ \&\&\ git\ clone\ file:///home/myokoym/work/groonga/rroonga/.git\ tmp/windows\ \&\&\ cd\ tmp/windows\ \&\&\ gem\ install\ json\ \&\&\ bundle\ \&\&\ rake\ cross\ native\ gem\ RUBY_CC_VERSION\\\=2.1.6:2.2.2:2.3.0:2.4.0:2.5.0]
/home/myokoym/work/groonga/rroonga/Rakefile:191:in `block (4 levels) in <top (required)>'
/home/myokoym/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
/home/myokoym/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
Tasks: TOP => build:windows => build:windows:x86
(See full trace by running task with --trace)
```
