### PR TITLE
RegexpExpressionBuilder: use (?-mix:XXX) for searching of regular expression

### DIFF
--- a/lib/groonga/expression-builder.rb
+++ b/lib/groonga/expression-builder.rb
@@ -186,7 +186,7 @@ module Groonga
         end
 
         if other.is_a?(Regexp)
-          RegexpExpressionBuilder.new(self, normalize(other.source))
+          RegexpExpressionBuilder.new(self, normalize(other.to_s))
         else
           MatchExpressionBuilder.new(self, normalize(other))
         end

--- a/test/test-expression-builder.rb
+++ b/test/test-expression-builder.rb
@@ -303,14 +303,6 @@ class ExpressionBuilderTest < Test::Unit::TestCase
                      result.collect {|record| record.key.key}.sort)
       end
 
-      def test_match_include_uppercase
-        result = @users.select do |record|
-          record["name"] =~ /Su/i
-        end
-        assert_equal(["suzuki"],
-                     result.collect {|record| record.key.key}.sort)
-      end
-
       def test_not_match
         result = @users.select do |record|
           record["name"] =~ /abcabcabc/
@@ -330,6 +322,14 @@ class ExpressionBuilderTest < Test::Unit::TestCase
       def test_end_of_text
         result = @users.select do |record|
           record["name"] =~ /ki\z/
+        end
+        assert_equal(["suzuki"],
+                     result.collect {|record| record.key.key}.sort)
+      end
+
+      def test_option
+        result = @users.select do |record|
+          record["name"] =~ /Su/i
         end
         assert_equal(["suzuki"],
                      result.collect {|record| record.key.key}.sort)

--- a/test/test-expression-builder.rb
+++ b/test/test-expression-builder.rb
@@ -303,6 +303,14 @@ class ExpressionBuilderTest < Test::Unit::TestCase
                      result.collect {|record| record.key.key}.sort)
       end
 
+      def test_match_uppercase
+        result = @users.select do |record|
+          record["name"] =~ /\ASu/i
+        end
+        assert_equal(["suzuki"],
+                     result.collect {|record| record.key.key}.sort)
+      end
+
       def test_not_match
         result = @users.select do |record|
           record["name"] =~ /abcabcabc/

--- a/test/test-expression-builder.rb
+++ b/test/test-expression-builder.rb
@@ -303,9 +303,9 @@ class ExpressionBuilderTest < Test::Unit::TestCase
                      result.collect {|record| record.key.key}.sort)
       end
 
-      def test_match_uppercase
+      def test_match_include_uppercase
         result = @users.select do |record|
-          record["name"] =~ /\ASu/i
+          record["name"] =~ /Su/i
         end
         assert_equal(["suzuki"],
                      result.collect {|record| record.key.key}.sort)


### PR DESCRIPTION
Groonga accepts `(?-mix:XXX)` since version 8.0.8.
We send  `(?-mix:XXX) ` to Groonga from Rroonga.

We can use ignore case option when we search for a regular expression by this modify.
We can use a regular expression include an upper case for searching.