### PR TITLE
test: add a n_jobs value

### DIFF
--- a/test/test-remote.rb
+++ b/test/test-remote.rb
@@ -83,6 +83,7 @@ class RemoteTest < Test::Unit::TestCase
                    "command_version",
                    "default_command_version",
                    "max_command_version",
+                   "n_jobs",
                    "n_queries",
                    "start_time",
                    "starttime",


### PR DESCRIPTION
Because added "n_jobs" into return value of "status" from Groonga 9.0.9.