### PR TITLE
test: follow Groonga 10.1.0 change

### DIFF
--- a/test/test-remote.rb
+++ b/test/test-remote.rb
@@ -94,9 +94,11 @@ class RemoteTest < Test::Unit::TestCase
     values = JSON.load(result)
     assert_equal([
                    "alloc_count",
+                   "apache_arrow",
                    "cache_hit_rate",
                    "command_version",
                    "default_command_version",
+                   "features",
                    "max_command_version",
                    "n_jobs",
                    "n_queries",


### PR DESCRIPTION
status command returns "apache_arrow" and "features" since Groonga 10.1.0.

This PR should merge after Groonga 10.1.0 will be released.
Because if we merge this now, tests fail except " Ruby 2.7 with Groonga master".