### PR TITLE
ci ruby2.5: add a missing dependency gem

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,9 @@ jobs:
           gem install `
             packnga `
             yard
+          if ("${{ matrix.ruby-version }}" -eq "2.5") {
+            gem install bundler
+          }
       - name: Build gem
         run: |
           rake build


### PR DESCRIPTION
Because Ruby 2.5 doesn't bundle bundler.