### PR TITLE
Install groonga when native package is not installed

### DIFF
--- a/ext/groonga/extconf.rb
+++ b/ext/groonga/extconf.rb
@@ -226,9 +226,9 @@ end
 
 need_auto_groonga_install = false
 unless PKGConfig.have_package(package_name, major, minor, micro)
-  unless NativePackageInstaller.install(debian: "libgroonga-dev",
-                                        homebrew: "groonga",
-                                        msys2: "groonga")
+  if NativePackageInstaller.install(debian: "libgroonga-dev",
+                                    homebrew: "groonga",
+                                    msys2: "groonga")
     need_auto_groonga_install =
       !PKGConfig.have_package(package_name, major, minor, micro)
   end

--- a/ext/groonga/extconf.rb
+++ b/ext/groonga/extconf.rb
@@ -226,9 +226,9 @@ end
 
 need_auto_groonga_install = false
 unless PKGConfig.have_package(package_name, major, minor, micro)
-  if NativePackageInstaller.install(debian: "libgroonga-dev",
-                                    homebrew: "groonga",
-                                    msys2: "groonga")
+  unless NativePackageInstaller.install(debian: "libgroonga-dev",
+                                        homebrew: "groonga",
+                                        msys2: "groonga")
     need_auto_groonga_install =
       !PKGConfig.have_package(package_name, major, minor, micro)
   end

--- a/ext/groonga/extconf.rb
+++ b/ext/groonga/extconf.rb
@@ -231,6 +231,8 @@ unless PKGConfig.have_package(package_name, major, minor, micro)
                                     msys2: "groonga")
     need_auto_groonga_install =
       !PKGConfig.have_package(package_name, major, minor, micro)
+  else
+    need_auto_groonga_install = true
   end
 end
 if need_auto_groonga_install


### PR DESCRIPTION
I am unable to install Rroonga unless I have installed Groonga beforehand.

That's because the judgment of "Do you need automatic installation?" is wrong, and it seems to me that the truth is being judged backwards.