### PR TITLE
ci: remove Ruby 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
           - macos-latest
           - windows-latest
         ruby-version:
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"


### PR DESCRIPTION
Because Ruby 2.7 reached EOL 31 Mar 2023.