### PR TITLE
test: fix an expected raised error about RemoteTest#test_invalid_select

### DIFF
--- a/test/test-remote.rb
+++ b/test/test-remote.rb
@@ -114,7 +114,8 @@ class RemoteTest < Test::Unit::TestCase
   def test_invalid_select
     context.connect(:host => @host, :port => @port)
 
-    assert_raise(Groonga::InvalidArgument) do
+    # Return code 65514 is INVALID_ARGUMENT in GQTP.
+    assert_raise(Groonga::Error.new("invalid return code: 65514")) do
       context.select("bogus", :query => "()()")
     end
   end


### PR DESCRIPTION
This PR fixed the following error in RemoteTest#test_invalid_select. Because in GQTP protocol, the return code about `INVALID_ARGUMENT` isn't GRN_INVALID_ARGUMENT(-22) but INVALID_ARGUMENT(65514).

```
Failure: test_invalid_select(RemoteTest)
/Users/runner/work/rroonga/rroonga/tmp/test/test-remote.rb:117:in `test_invalid_select'
     114:   def test_invalid_select
     115:     context.connect(:host => @host, :port => @port)
     116:
  => 117:     assert_raise(Groonga::InvalidArgument) do
     118:       context.select("bogus", :query => "()()")
     119:     end
     120:   end

<Groonga::InvalidArgument> expected but was
<Groonga::Error(<invalid return code: 65514>)
```