### PR TITLE
Use bool instead of grn_bool in rb-grn-less-operator.c

### DIFF
--- a/ext/groonga/rb-grn-less-operator.c
+++ b/ext/groonga/rb-grn-less-operator.c
@@ -46,7 +46,7 @@ VALUE rb_cGrnLessOperator;
 static VALUE
 rb_grn_less_operator_exec (int argc, VALUE *argv, VALUE self)
 {
-    grn_bool less;
+    bool less;
     VALUE rb_x;
     VALUE rb_y;
     VALUE rb_options;


### PR DESCRIPTION
Replacing grn_bool with bool in Groonga.
https://github.com/groonga/groonga/issues/1638

https://github.com/groonga/groonga/blob/v15.0.2/include/groonga/operator.h#L39-L40